### PR TITLE
Fix compiling large sprites on 6309

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,10 +122,12 @@ endif
 ifeq ($(CPU),6309)
   ASMFLAGS += --define=CPU=6309
   LOADERSRC += $(SRCDIR)/graphics-blockdraw-6309.asm
+  MAMESYSTEM = coco3h
 else
   CPU = 6809
   ASMFLAGS += --define=CPU=6809
   LOADERSRC += $(SRCDIR)/graphics-blockdraw-6809.asm
+  MAMESYSTEM = coco3
 endif
 ifeq ($(MAMEDBG), 1)
   MAMEFLAGS += -debug
@@ -158,7 +160,7 @@ clean:
 	rm -rf $(GENASMDIR) $(GENGFXDIR) $(GENOBJDIR) $(GENDISKDIR) $(GENLISTDIR) $(GENTMPDIR)
 
 test:
-	$(EMULATOR) coco3 -flop1 $(TARGET) $(MAMEFLAGS) -window -waitvsync -resolution 640x480 -video opengl -rompath ~/Applications/mame/roms
+	$(EMULATOR) $(MAMESYSTEM) -flop1 $(TARGET) $(MAMEFLAGS) -window -waitvsync -resolution 640x480 -video opengl -rompath ~/Applications/mame/roms
 
 # build rules
 

--- a/scripts/sprite2asm.py
+++ b/scripts/sprite2asm.py
@@ -745,9 +745,17 @@ class Sprite:
                 thisCmd = byteCmds[byteIdx]
                 byteOffCmdList.append((off0+byteIdx, dstOffset, thisCmd[0], thisCmd[1], thisCmd[2]))
                 dstOffset += 1
-        # exhaustively search all permutations of store/write commands, and return best result
+
+        # in block of n commands, exhaustively search all permutations of store/write commands, and return best result
+        # we choose n = 12 as a compromise for compile time performance and runtime performance
+        n = 12
         layoutDict = { 1:[], 2:[], 4:[] }
-        return self.Permute6309StoreLayouts(regState, layoutDict, byteOffCmdList, 4)
+        results = [self.Permute6309StoreLayouts(regState, layoutDict, byteOffCmdList[ii:ii + n], 4)
+                      for ii in range(0, len(byteOffCmdList), n)]
+        return_value = results[0]
+        for ii in range(1, len(results)):
+            return_value += results[ii]
+        return return_value
 
     def Permute6309StoreLayouts(self, regState, layoutDict, byteOffCmdList, searchSize):
         cmdListLen = len(byteOffCmdList)


### PR DESCRIPTION
This pull request breaks up the compilation of very wide sprites on the 6309 into chunks of 12 bytes. While this leads to less efficient generated code, it does make the Python run in a reasonable amount of time.