### PR TITLE
Extend objcode size

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,20 @@ that contains both the CoCo 3 and macOS versions.
 Type `make` by itself to view all available build options:
 ```
  $ make
-DynoSprite makefile.
+DynoSprite makefile. 
   Targets:
-    all           == Build disk image
-    clean         == remove binary and output files
-    test          == run test in MAME
+    all            == Build disk image
+    clean          == remove binary and output files
+    test           == run test in MAME
   Build Options:
-    RELEASE=1     == build without bounds checking / SWI instructions
-    SPEEDTEST=1   == run loop during idle and count time for analysis
-    VISUALTIME=1  == set screen width to 256 and change border color
-    CPU=6309      == build with faster 6309-specific instructions
+    RELEASE=1      == build without bounds checking / SWI instructions
+    SPEEDTEST=1    == run loop during idle and count time for analysis
+    VISUALTIME=1   == set screen width to 256 and change border color
+    CPU=6309       == build with faster 6309-specific instructions
+    OBJPAGES=1     == num of pages to use levels and objects
+    OBJPAGEGUARD=0 == num bytes to reserve at top of each object code page
   Debugging Options:
-    MAMEDBG=1     == run MAME with debugger window (for 'test' target)
+    MAMEDBG=1      == run MAME with debugger window (for 'test' target)
 ```
 
 Special notes about audio conversion:

--- a/engine/c-object-entry.asm
+++ b/engine/c-object-entry.asm
@@ -93,7 +93,7 @@ ObjectDescriptorTable:
                         fdb     Object_Reactivate
                         fdb     Object_Update
                         fdb     0                           * custom draw function
-                        fcb     0                           * vpage
+                        fdb     0                           * vpageAddr
                         fdb     0,0                         * res2
 
 Object_Init EXPORT

--- a/engine/c-object-entry.asm
+++ b/engine/c-object-entry.asm
@@ -93,6 +93,7 @@ ObjectDescriptorTable:
                         fdb     Object_Reactivate
                         fdb     Object_Update
                         fdb     0                           * custom draw function
+                        fcb     0                           * vpage
                         fdb     0,0                         * res2
 
 Object_Init EXPORT

--- a/engine/datastruct.asm
+++ b/engine/datastruct.asm
@@ -221,7 +221,7 @@ init                    rmd     1
 reactivate              rmd     1
 update                  rmd     1
 draw                    rmd     1
-vpageAddr               rmb     2
+vpageAddr               rmd     1
 res2                    rmd     2
             ENDSTRUCT
 

--- a/engine/datastruct.asm
+++ b/engine/datastruct.asm
@@ -221,6 +221,7 @@ init                    rmd     1
 reactivate              rmd     1
 update                  rmd     1
 draw                    rmd     1
+vpage                   rmb     1
 res2                    rmd     2
             ENDSTRUCT
 

--- a/engine/datastruct.asm
+++ b/engine/datastruct.asm
@@ -221,7 +221,7 @@ init                    rmd     1
 reactivate              rmd     1
 update                  rmd     1
 draw                    rmd     1
-vpage                   rmb     1
+vpageAddr               rmb     2
 res2                    rmd     2
             ENDSTRUCT
 

--- a/engine/dynosprite.h
+++ b/engine/dynosprite.h
@@ -47,7 +47,7 @@ typedef struct DynospriteODT {
   void *reactivate;
   void *update;
   void *draw;
-  byte vpage;
+  void *vpageAddr;
   byte res2[4];
 } DynospriteODT;
 

--- a/engine/dynosprite.h
+++ b/engine/dynosprite.h
@@ -217,8 +217,7 @@ typedef struct DynospriteGlobals {
   byte Img_Random161[161];
   byte Img_Random200[200];
 
-  byte UserGlobals_Init;
-  byte UserGlobals[31];
+  byte UserGlobals[32];
 } DynospriteGlobals;
 
 
@@ -226,7 +225,7 @@ typedef struct DynospriteGlobals {
 #define DynospriteDirectPageGlobalsPtr ((DynospriteDirectPageGlobals *)0x2000)
 
 /** Pointer to the Dynopsprite Globals */
-#define DynospriteGlobalsPtr ((DynospriteGlobals *)0x2100)
+#define DynospriteGlobalsPtr ((void *)0x2620)
 
 
 asm void PlaySound(byte val) {

--- a/engine/dynosprite.h
+++ b/engine/dynosprite.h
@@ -47,6 +47,7 @@ typedef struct DynospriteODT {
   void *reactivate;
   void *update;
   void *draw;
+  byte vpage;
   byte res2[4];
 } DynospriteODT;
 

--- a/engine/globals.asm
+++ b/engine/globals.asm
@@ -275,6 +275,7 @@ Img_Random200           fcb     154,113,57,130,163,17,86,168,108,37,79,94,69,192
 
 ***********************************************************
 * User Global Data
+UserGlobals
 UserGlobals_Init	fcb	0
-UserGlobals		rmb	31	
+                        rmb     31	
 

--- a/engine/loader.asm
+++ b/engine/loader.asm
@@ -523,6 +523,7 @@ LoadThisGroup@
 AllGroupsLoaded@
             * close the OBJECTS.DAT file
             jsr         Disk_FileClose
+
             * initialize the Objects with the OIT
             lda         #VH_BKTILES             * map the (temporary) page for OIT table into $4000
             ldb         #2
@@ -682,6 +683,8 @@ SkipSound2@
             lda         #1
             sta         Ldr_SkipSound
             * call the level's initialization function
+!           lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1 * Map in the first page
+            sta         $FFA3
             jsr         [Ldr_LDD.PtrInitLevel]
             * set up graphics variables
             jsr         Gfx_InitBkgrndBounds
@@ -910,6 +913,7 @@ SpriteLoop@
 	    sta         ObjCodeVirtualPage 
 	    ldd         #$6000                  * Store code at the beggining of the page
 	    tfr	        d,u
+            std         ObjCodePtr@
             addd        GroupObjCodeSize@
 *
 LoadObject@

--- a/engine/loader.asm
+++ b/engine/loader.asm
@@ -41,6 +41,7 @@ Ldr_ProgressBarPtr      zmb     2
 Ldr_ProgressBarPage     zmb     1
 Ldr_CurProgressSec      zmb     2
 Ldr_CurProgressPct      zmb     1
+                        zmb     1
 ObjCodeVirtualPage      zmb     1
 
 ***********************************************************
@@ -940,8 +941,9 @@ ObjectLoop@
             ldd         ODT.draw,x
             addd        ObjCodePtr@
             std         ODT.draw,x
-            lda         ObjCodeVirtualPage 
-            sta         ODT.vpage,x
+            ldy         ObjCodeVirtualPage-1
+            leay        MemMgr_VirtualTable,y
+            sty         ODT.vpageAddr,x
             puls        a
             leax        sizeof{ODT},x
             deca

--- a/engine/main.asm
+++ b/engine/main.asm
@@ -140,8 +140,8 @@ DrawObjLoop@
             ldb         ODT.drawType,u
             bne         >
             * custom drawing function
-            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1
-            sta         $FFA3                   * Map the Level/Object code page to $6000
+            ldb         [ODT.vpageAddr,u]       * load the page number
+            stb         $FFA3                   * Map the Level/Object code page to $6000
             jsr         [ODT.draw,u]
             bra         ThisObjDrawn@
 !           cmpb        #1
@@ -243,6 +243,8 @@ InputDone@
 UpdateObjLoop@
             pshs        a,x
             ldu         COB.odtPtr,x
+            ldb         [ODT.vpageAddr,u]       * load the page number
+            stb         $FFA3
             ldb         COB.active,x
             andb        #1
             beq         >

--- a/engine/main.asm
+++ b/engine/main.asm
@@ -137,11 +137,15 @@ DrawObjLoop@
             beq         SkipDraw@
             pshs        a,x
             ldu         COB.odtPtr,x
-            ldb         [ODT.vpageAddr,u]       * load the page number
-            stb         $FFA3                   * Map the Level/Object code page to $6000
             ldb         ODT.drawType,u
             bne         >
             * custom drawing function
+ IFEQ       OBJPAGES-1
+            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1
+ ELSE
+            lda         [ODT.vpageAddr,u]       * load the page number
+ ENDC
+            sta         $FFA3                   * Map the Level/Object code page to $6000
             jsr         [ODT.draw,u]
             bra         ThisObjDrawn@
 !           cmpb        #1
@@ -243,8 +247,10 @@ InputDone@
 UpdateObjLoop@
             pshs        a,x
             ldu         COB.odtPtr,x
+ IFNE       OBJPAGES-1
             ldb         [ODT.vpageAddr,u]       * load the page number
             stb         $FFA3
+ ENDC
             ldb         COB.active,x
             andb        #1
             beq         >

--- a/engine/main.asm
+++ b/engine/main.asm
@@ -140,7 +140,7 @@ DrawObjLoop@
             ldb         ODT.drawType,u
             bne         >
             * custom drawing function
-            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE
+            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1
             sta         $FFA3                   * Map the Level/Object code page to $6000
             jsr         [ODT.draw,u]
             bra         ThisObjDrawn@
@@ -183,7 +183,7 @@ DrawObjDone@
 InputDone@
 
             * 7. Calculate next frame background position (update Gfx_BkgrndNewX/Y)
-            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE
+            lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1
             sta         $FFA3                   * Map Level/Object code page at $6000 (fixme: is this needed here?)
             jsr         [Ldr_LDD.PtrCalcBkgrnd]
             * Setup the RedrawOldX/Y coordinates for the next frame's background draw operation

--- a/engine/main.asm
+++ b/engine/main.asm
@@ -137,11 +137,11 @@ DrawObjLoop@
             beq         SkipDraw@
             pshs        a,x
             ldu         COB.odtPtr,x
+            ldb         [ODT.vpageAddr,u]       * load the page number
+            stb         $FFA3                   * Map the Level/Object code page to $6000
             ldb         ODT.drawType,u
             bne         >
             * custom drawing function
-            ldb         [ODT.vpageAddr,u]       * load the page number
-            stb         $FFA3                   * Map the Level/Object code page to $6000
             jsr         [ODT.draw,u]
             bra         ThisObjDrawn@
 !           cmpb        #1

--- a/engine/memory.asm
+++ b/engine/memory.asm
@@ -43,7 +43,7 @@
 
 * Definitions
 *
-MAX_SPRITE_CODE_PAGES   EQU     25              * 64 - 28 (graphics aperture) - 6 (core code+rom) - 5 (min gfx+sound data)
+MAX_SPRITE_CODE_PAGES   EQU     24              * 64 - 28 (graphics aperture) - 7 (core code+rom) - 5 (min gfx+sound data)
 
 * Virtual Handle definitions for 8k pages which are fixed at program start time
 VH_CODE1        EQU     0                       * primary code page w/ stack, always resident at $2000
@@ -55,13 +55,14 @@ VH_DSKROM       EQU     4                       * Disk BASIC code image (used wh
 VH_HIGHROM      EQU     5                       * Top 8k of cartridge ROM space (used with CoCoNET MicroSD Pak)
 
 VH_SPRERASE     EQU     6                       * Sprite background pixels
-VH_LVLOBJCODE   EQU     7                       * Level and object handling code page
-VH_BKTILES      EQU     8                       * background block texture data (max 8 8k pages)
-VH_BKMAP        EQU     16                      * background tilemap (max 8 8k pages)
-VH_ZIPDATA      EQU     24                      * decompressor tables and large state data (one page)
-VH_ZIPBUF       EQU     25                      * decompressed data buffer (max 5 8k pages)
-VH_SOUNDDATA    EQU     30                      * audio waveform pages (max 8 8k pages)
-VH_SPRCODE      EQU     38                      * sprite draw/erase code pages
+VH_LVLOBJCODE1  EQU     7                       * Level and object handling code page
+VH_LVLOBJCODE2  EQU     8                       * Level and object handling code page
+VH_BKTILES      EQU     9                       * background block texture data (max 8 8k pages)
+VH_BKMAP        EQU     17                      * background tilemap (max 8 8k pages)
+VH_ZIPDATA      EQU     25                      * decompressor tables and large state data (one page)
+VH_ZIPBUF       EQU     26                      * decompressed data buffer (max 5 8k pages)
+VH_SOUNDDATA    EQU     31                      * audio waveform pages (max 8 8k pages)
+VH_SPRCODE      EQU     39                      * sprite draw/erase code pages
 
 ***********************************************************
 * MemMgr_Init

--- a/engine/memory.asm
+++ b/engine/memory.asm
@@ -43,7 +43,7 @@
 
 * Definitions
 *
-MAX_SPRITE_CODE_PAGES   EQU     24              * 64 - 28 (graphics aperture) - 7 (core code+rom) - 5 (min gfx+sound data)
+MAX_SPRITE_CODE_PAGES   EQU     26-OBJPAGES     * 64 - 28 (graphics aperture) - 5 (core code+rom) - 5 (min gfx+sound data) - OBJPAGES
 
 * Virtual Handle definitions for 8k pages which are fixed at program start time
 VH_CODE1        EQU     0                       * primary code page w/ stack, always resident at $2000
@@ -55,14 +55,14 @@ VH_DSKROM       EQU     4                       * Disk BASIC code image (used wh
 VH_HIGHROM      EQU     5                       * Top 8k of cartridge ROM space (used with CoCoNET MicroSD Pak)
 
 VH_SPRERASE     EQU     6                       * Sprite background pixels
-VH_LVLOBJCODE1  EQU     7                       * Level and object handling code page
-VH_LVLOBJCODE2  EQU     8                       * Level and object handling code page
-VH_BKTILES      EQU     9                       * background block texture data (max 8 8k pages)
-VH_BKMAP        EQU     17                      * background tilemap (max 8 8k pages)
-VH_ZIPDATA      EQU     25                      * decompressor tables and large state data (one page)
-VH_ZIPBUF       EQU     26                      * decompressed data buffer (max 5 8k pages)
-VH_SOUNDDATA    EQU     31                      * audio waveform pages (max 8 8k pages)
-VH_SPRCODE      EQU     39                      * sprite draw/erase code pages
+VH_LVLOBJCODE1  EQU     7                       * First level and object handling code page
+VH_LVLOBJCODEX  EQU     7+OBJPAGES-1            * Last level and object handling code page
+VH_BKTILES      EQU     8+OBJPAGES-1            * background block texture data (max 8 8k pages)
+VH_BKMAP        EQU     16+OBJPAGES-1           * background tilemap (max 8 8k pages)
+VH_ZIPDATA      EQU     24+OBJPAGES-1           * decompressor tables and large state data (one page)
+VH_ZIPBUF       EQU     25+OBJPAGES-1           * decompressed data buffer (max 5 8k pages)
+VH_SOUNDDATA    EQU     30+OBJPAGES-1           * audio waveform pages (max 8 8k pages)
+VH_SPRCODE      EQU     38+OBJPAGES-1           * sprite draw/erase code pages
 
 ***********************************************************
 * MemMgr_Init

--- a/engine/object.asm
+++ b/engine/object.asm
@@ -119,6 +119,8 @@ ObjectLoop2@
             puls        a
             deca
             bne         ObjectLoop2@
+!           lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1 * Map in the first page
+            sta         $FFA3
             rts
 
 ***********************************************************

--- a/engine/object.asm
+++ b/engine/object.asm
@@ -108,6 +108,8 @@ ObjectLoop2@
             std         COB.statePtr,x          * the state data pointer is now correct
             leau        7,u                     * point to the initialization data for this object in the object init stream
             ldy         COB.odtPtr,x
+            lda         [ODT.vpageAddr,y]       * load the page number
+            sta         $FFA3                   * load the page
             pshs        u,y,x
             jsr         [ODT.init,y]            * call the initialization function for this object type
             puls        x,y,u

--- a/game/levels/01-persei.c
+++ b/game/levels/01-persei.c
@@ -8,7 +8,7 @@ extern "C" {
 
     
 void PerseiInit() {
-    GameGlobals *globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+    GameGlobals *globals = (GameGlobals *)DynospriteGlobalsPtr;
     memset(globals, 0, sizeof(*globals));
     globals->numShips = 3;
     globals->initialized = TRUE;

--- a/game/objects/01-numerals.asm
+++ b/game/objects/01-numerals.asm
@@ -295,6 +295,7 @@ ObjectDescriptorTable
                         fdb     Demo_Object0_Reactivate
                         fdb     Demo_Object0_Update
                         fdb     Demo_Object0_Draw
+                        fcb     0               * vpage
                         fdb     0,0             * res2
 
                         fcb     3               * dataSize
@@ -305,5 +306,6 @@ ObjectDescriptorTable
                         fdb     Demo_Object1_Reactivate
                         fdb     Demo_Object1_Update
                         fdb     Demo_Object1_Draw
+                        fcb     0               * vpage
                         fdb     0,0             * res2
 

--- a/game/objects/01-numerals.asm
+++ b/game/objects/01-numerals.asm
@@ -295,7 +295,7 @@ ObjectDescriptorTable
                         fdb     Demo_Object0_Reactivate
                         fdb     Demo_Object0_Update
                         fdb     Demo_Object0_Draw
-                        fcb     0               * vpage
+                        fdb     0               * vpageAddr
                         fdb     0,0             * res2
 
                         fcb     3               * dataSize
@@ -306,6 +306,6 @@ ObjectDescriptorTable
                         fdb     Demo_Object1_Reactivate
                         fdb     Demo_Object1_Update
                         fdb     Demo_Object1_Draw
-                        fcb     0               * vpage
+                        fdb     0               * vpageAddr
                         fdb     0,0             * res2
 

--- a/game/objects/02-balls.asm
+++ b/game/objects/02-balls.asm
@@ -670,6 +670,7 @@ ObjectDescriptorTable
                         fdb     Demo_Grp2Object0_Reactivate
                         fdb     Demo_Grp2Object0_Update
                         fdb     0               * custom draw function
+                        fcb     0               * vpage
                         fdb     0,0             * res2
 
 

--- a/game/objects/02-balls.asm
+++ b/game/objects/02-balls.asm
@@ -670,7 +670,7 @@ ObjectDescriptorTable
                         fdb     Demo_Grp2Object0_Reactivate
                         fdb     Demo_Grp2Object0_Update
                         fdb     0               * custom draw function
-                        fcb     0               * vpage
+                        fdb     0               * vpageAddr
                         fdb     0,0             * res2
 
 

--- a/game/objects/03-badguy.c
+++ b/game/objects/03-badguy.c
@@ -148,7 +148,7 @@ void BadguyInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
     if (!didInit) {
         didInit = TRUE;
         numInvaders = 0;
-        globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+        globals = (GameGlobals *)DynospriteGlobalsPtr;
 
         DynospriteCOB *obj = DynospriteDirectPageGlobalsPtr->Obj_CurrentTablePtr;
         for (byte ii=0; obj && ii<sizeof(badMissiles)/sizeof(badMissiles[0]); ii++) {

--- a/game/objects/04-ship.c
+++ b/game/objects/04-ship.c
@@ -124,7 +124,7 @@ DynospriteCOB *findFreeMissile() {
 void ShipInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
     if (didNotInit) {
         didNotInit = FALSE;
-        globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+        globals = (GameGlobals *)DynospriteGlobalsPtr;
         DynospriteCOB *obj = DynospriteDirectPageGlobalsPtr->Obj_CurrentTablePtr;
         for (byte ii=0; obj && ii<sizeof(missiles)/sizeof(missiles[0]); ii++) {
             obj = findObjectByGroup(obj, MISSILE_GROUP_IDX);

--- a/game/objects/05-missile.c
+++ b/game/objects/05-missile.c
@@ -23,7 +23,7 @@ void MissileClassInit() {
 void MissileInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
     if (didNotInit) {
         didNotInit = FALSE;
-        globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+        globals = (GameGlobals *)DynospriteGlobalsPtr;
         endBadGuys = &(badGuys[sizeof(badGuys)/sizeof(badGuys[0])]);
         DynospriteCOB *obj = DynospriteDirectPageGlobalsPtr->Obj_CurrentTablePtr;
         for (byte ii=0; obj && ii<sizeof(badGuys)/sizeof(badGuys[0]); ii++) {

--- a/game/objects/06-gameover.c
+++ b/game/objects/06-gameover.c
@@ -30,7 +30,7 @@ void GameoverInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
 
 byte GameoverReactivate(DynospriteCOB *cob, DynospriteODT *odt) {
     byte *matrix = DynospriteDirectPageGlobalsPtr->Input_KeyMatrix;
-    GameGlobals *globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+    GameGlobals *globals = (GameGlobals *)DynospriteGlobalsPtr;
     GameOverObjectState *statePtr = (GameOverObjectState *)(cob->statePtr);
     
     // Make sure the p button is unpressed
@@ -67,7 +67,7 @@ byte GameoverReactivate(DynospriteCOB *cob, DynospriteODT *odt) {
 
 byte GameoverUpdate(DynospriteCOB *cob, DynospriteODT *odt) {
     byte *matrix = DynospriteDirectPageGlobalsPtr->Input_KeyMatrix;
-    GameGlobals *globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+    GameGlobals *globals = (GameGlobals *)DynospriteGlobalsPtr;
     GameOverObjectState *statePtr = (GameOverObjectState *)(cob->statePtr);
 
     cob->globalX = statePtr->initX + (2 * DynospriteDirectPageGlobalsPtr->Gfx_BkgrndNewX);

--- a/game/objects/07-badmissile.c
+++ b/game/objects/07-badmissile.c
@@ -26,7 +26,7 @@ void BadmissileClassInit() {
 void BadmissileInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
     if (!didInit) {
         didInit = TRUE;
-        globals = (GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init);
+        globals = (GameGlobals *)DynospriteGlobalsPtr;
     }
     DynospriteCOB *obj = DynospriteDirectPageGlobalsPtr->Obj_CurrentTablePtr;
     shipCob = findObjectByGroup(obj, SHIP_GROUP_IDX);

--- a/game/objects/08-shipcounter.c
+++ b/game/objects/08-shipcounter.c
@@ -21,7 +21,7 @@ void ShipcounterClassInit() {
 
 
 void ShipcounterInit(DynospriteCOB *cob, DynospriteODT *odt, byte *initData) {
-    globals = (GameGlobals *)&DynospriteGlobalsPtr->UserGlobals_Init;
+    globals = (GameGlobals *)DynospriteGlobalsPtr;
     ShipCounterObjectState *state = (ShipCounterObjectState *)cob->statePtr;
     state->spriteIdx = 0;
     state->numShips = initData[0];

--- a/game/objects/object_info.h
+++ b/game/objects/object_info.h
@@ -125,7 +125,7 @@ static void bumpScore(byte amount) {
         }
     }
 #else
-    byte *score0 = ((GameGlobals *)&(DynospriteGlobalsPtr->UserGlobals_Init))->score;
+    byte *score0 = ((GameGlobals *)DynospriteGlobalsPtr)->score;
     asm {
         ldx score0
 

--- a/makefile
+++ b/makefile
@@ -129,6 +129,16 @@ else
   LOADERSRC += $(SRCDIR)/graphics-blockdraw-6809.asm
   MAMESYSTEM = coco3
 endif
+ifeq ($(OBJPAGES),)
+  ASMFLAGS += --define=OBJPAGES=1
+else
+  ASMFLAGS += --define=OBJPAGES=$(OBJPAGES)
+endif
+ifeq ($(OBJPAGEGUARD),)
+  ASMFLAGS += --define=OBJPAGEGUARD=0
+else
+  ASMFLAGS += --define=OBJPAGEGUARD=$(OBJPAGEGUARD)
+endif
 ifeq ($(MAMEDBG), 1)
   MAMEFLAGS += -debug
 endif
@@ -140,16 +150,18 @@ TARGET = $(BUILDDIR)/BNDT$(CPU).DSK
 targets:
 	@echo "DynoSprite makefile. "
 	@echo "  Targets:"
-	@echo "    all           == Build disk image"
-	@echo "    clean         == remove binary and output files"
-	@echo "    test          == run test in MAME"
+	@echo "    all            == Build disk image"
+	@echo "    clean          == remove binary and output files"
+	@echo "    test           == run test in MAME"
 	@echo "  Build Options:"
-	@echo "    RELEASE=1     == build without bounds checking / SWI instructions"
-	@echo "    SPEEDTEST=1   == run loop during idle and count time for analysis"
-	@echo "    VISUALTIME=1  == set screen width to 256 and change border color"
-	@echo "    CPU=6309      == build with faster 6309-specific instructions"
+	@echo "    RELEASE=1      == build without bounds checking / SWI instructions"
+	@echo "    SPEEDTEST=1    == run loop during idle and count time for analysis"
+	@echo "    VISUALTIME=1   == set screen width to 256 and change border color"
+	@echo "    CPU=6309       == build with faster 6309-specific instructions"
+	@echo "    OBJPAGES=1     == num of pages to use levels and objects"
+	@echo "    OBJPAGEGUARD=0 == num bytes to reserve at top of each object code page"
 	@echo "  Debugging Options:"
-	@echo "    MAMEDBG=1     == run MAME with debugger window (for 'test' target)"
+	@echo "    MAMEDBG=1      == run MAME with debugger window (for 'test' target)"
 
 # this special target is used to prevent gnu make from deleting the intermediate sprite .txt and .asm files
 SECONDARY: $(SPRITESRC) $(SPRITEASMSRC)

--- a/scripts/build-objects.py
+++ b/scripts/build-objects.py
@@ -72,7 +72,7 @@ class Group:
         if len(self.SprRaw) != sdtStart + self.numSprites * 16:
             print(f"****Error: group {int(self.grpNumber)} sprite raw code file length is wrong")
             sys.exit(1)
-        if len(self.ObjRaw) != odtStart + self.numObjects * 16:
+        if len(self.ObjRaw) != odtStart + self.numObjects * 17:
             print("****Error: group {} object raw code file length is wrong: {} {}" \
               .format(self.numObjects, len(self.ObjRaw), odtStart + self.numObjects * 16))
             sys.exit(1)

--- a/scripts/build-objects.py
+++ b/scripts/build-objects.py
@@ -72,7 +72,7 @@ class Group:
         if len(self.SprRaw) != sdtStart + self.numSprites * 16:
             print(f"****Error: group {int(self.grpNumber)} sprite raw code file length is wrong")
             sys.exit(1)
-        if len(self.ObjRaw) != odtStart + self.numObjects * 17:
+        if len(self.ObjRaw) != odtStart + self.numObjects * 18:
             print("****Error: group {} object raw code file length is wrong: {} {}" \
               .format(self.numObjects, len(self.ObjRaw), odtStart + self.numObjects * 16))
             sys.exit(1)


### PR DESCRIPTION
This merge request adds support for loading in Level and Object code segments that span multiple 8K pages. This feature can be turned on via the `makefile` options:
* `OBJPAGES` which defaults to 1
* `OBJPAGEGUARD` which defaults to 0

`OBJPAGES` is the number of 8K pages that can be loaded in for Level and Object code in each level.
`OBJPAGEGUARD` is the minimum number of extra bytes at the top of each 8K that can be used for different purposes such as additional stack space.
