### PR TITLE
Increase num of blocks used for levels and objects

### DIFF
--- a/engine/loader.asm
+++ b/engine/loader.asm
@@ -239,9 +239,7 @@ SetFrontBufBackground@
             jsr         Img_FadeIn
             * Allocate 8k blocks to store Level and Object code, and map first to $6000
             lda         #VH_LVLOBJCODEX
-!           pshs        a
-            jsr         MemMgr_AllocateBlock
-            puls        a
+!           jsr         MemMgr_AllocateBlock
             cmpa        #VH_LVLOBJCODE1
             beq         >
             deca
@@ -900,15 +898,15 @@ SpriteLoop@
             tfr         d,u
             std         ObjCodePtr@
             addd        GroupObjCodeSize@
- IFDEF DEBUG
             cmpd        #$8000-OBJPAGEGUARD     * are we beyond the page - the guard space?
             bls         LoadObject@
- ENDC
 *
+ IFDEF DEBUG
             lda         ObjCodeVirtualPage      * Did we already hit the second page?
 	    cmpa        #VH_LVLOBJCODEX
             bne         >                       * No, nothing to see here
             swi                                 * Error: out of memory for level / object code
+ ENDC
 *
 * We have to map in another page and record the fact that we are doing that
 !           inc         ObjCodeVirtualPage      * increment to the next virtual page
@@ -1119,10 +1117,14 @@ ProgressDone@
 Ldr_Unload_Level
             * 1. Start by freeing all of the 8k blocks allocated
             lda         #VH_LVLOBJCODE1         * free the level/object code page
+!           pshs        a
             jsr         MemMgr_FreeBlock
-            lda         #VH_LVLOBJCODEX
-            jsr         MemMgr_FreeBlock
-            ldb         Ldr_NumSpriteCodePages  * free the Sprite Draw/Erase code pages
+            puls        a
+            cmpa        #VH_LVLOBJCODEX
+            beq         >
+            inca
+            bra         <
+!           ldb         Ldr_NumSpriteCodePages  * free the Sprite Draw/Erase code pages
             lda         #VH_SPRCODE
 FreeSpritePages@
             pshs        a,b,x

--- a/engine/loader.asm
+++ b/engine/loader.asm
@@ -784,18 +784,15 @@ ObjCodeVirtualPage@     zmb     2
 Ldr_Load_SpriteGroup
             * Start by setting up this group's entry in the Sprite Group Table
             lda         <Gfx_NumSpriteGroups    * calculate starting pointer to this group's SGT entry
-            pshs        a
-            inc         <Gfx_NumSpriteGroups
-            ldb         #sizeof{SGT}
+            bne         >                       * branch if ObjCodeVirtualPage@ already initialized?
+            ldb         #VH_LVLOBJCODE1         * initialize ObjCodeVirtualPage@ with first code page
+            stb         ObjCodeVirtualPage@+1
+!           inc         <Gfx_NumSpriteGroups    * increment to next group SGT entry for next call
+            ldb         #sizeof{SGT}            * resume calc of pointer to this group's SGT entry
             mul
             ldx         <Gfx_SpriteGroupsPtr
             ADD_D_TO_X
-            puls	a
-            tsta
-            bne         >
-            lda         #VH_LVLOBJCODE1
-            sta         ObjCodeVirtualPage@+1
-!           ldd         GDO.ObjCodeSize,y       * store this group's object code size in a local variable
+            ldd         GDO.ObjCodeSize,y       * store this group's object code size in a local variable
             std         GroupObjCodeSize@
             ldd         GDO.CompSpriteCodeSize,y
             std         GroupCompSpriteCode@

--- a/engine/memory.asm
+++ b/engine/memory.asm
@@ -55,14 +55,14 @@ VH_DSKROM       EQU     4                       * Disk BASIC code image (used wh
 VH_HIGHROM      EQU     5                       * Top 8k of cartridge ROM space (used with CoCoNET MicroSD Pak)
 
 VH_SPRERASE     EQU     6                       * Sprite background pixels
-VH_LVLOBJCODE1  EQU     7                       * First level and object handling code page
-VH_LVLOBJCODEX  EQU     7+OBJPAGES-1            * Last level and object handling code page
-VH_BKTILES      EQU     8+OBJPAGES-1            * background block texture data (max 8 8k pages)
-VH_BKMAP        EQU     16+OBJPAGES-1           * background tilemap (max 8 8k pages)
-VH_ZIPDATA      EQU     24+OBJPAGES-1           * decompressor tables and large state data (one page)
-VH_ZIPBUF       EQU     25+OBJPAGES-1           * decompressed data buffer (max 5 8k pages)
-VH_SOUNDDATA    EQU     30+OBJPAGES-1           * audio waveform pages (max 8 8k pages)
-VH_SPRCODE      EQU     38+OBJPAGES-1           * sprite draw/erase code pages
+VH_BKTILES      EQU     7                       * background block texture data (max 8 8k pages)
+VH_BKMAP        EQU     15                      * background tilemap (max 8 8k pages)
+VH_ZIPDATA      EQU     23                      * decompressor tables and large state data (one page)
+VH_ZIPBUF       EQU     24                      * decompressed data buffer (max 5 8k pages)
+VH_SOUNDDATA    EQU     29                      * audio waveform pages (max 8 8k pages)
+VH_SPRCODE      EQU     37                      * sprite draw/erase code pages
+VH_LVLOBJCODE1  EQU     63-OBJPAGES+1           * First level and object handling code page
+VH_LVLOBJCODEX  EQU     63                      * Last level and object handling code page
 
 ***********************************************************
 * MemMgr_Init

--- a/engine/object.asm
+++ b/engine/object.asm
@@ -108,8 +108,10 @@ ObjectLoop2@
             std         COB.statePtr,x          * the state data pointer is now correct
             leau        7,u                     * point to the initialization data for this object in the object init stream
             ldy         COB.odtPtr,x
+ IFNE       OBJPAGES-1
             lda         [ODT.vpageAddr,y]       * load the page number
             sta         $FFA3                   * load the page
+ ENDC
             pshs        u,y,x
             jsr         [ODT.init,y]            * call the initialization function for this object type
             puls        x,y,u
@@ -119,8 +121,10 @@ ObjectLoop2@
             puls        a
             deca
             bne         ObjectLoop2@
+ IFNE       OBJPAGES-1
 !           lda         <MemMgr_VirtualTable+VH_LVLOBJCODE1 * Map in the first page
             sta         $FFA3
+ ENDC
             rts
 
 ***********************************************************


### PR DESCRIPTION
Pull request to accomplish what is done in https://github.com/richard42/dynosprite/pull/7

This merge request adds support for loading in Level and Object code segments that span multiple 8K pages. This feature can be turned on via the makefile options:

OBJPAGES which defaults to 1
OBJPAGEGUARD which defaults to 0
OBJPAGES is the number of 8K pages that can be loaded in for Level and Object code in each level.
OBJPAGEGUARD is the minimum number of extra bytes at the top of each 8K that can be used for different purposes such as additional stack space.