### PR TITLE
Remove hardcoded Xcode 11.7 path from release workflow

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -38,8 +38,6 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Build and test macOS application
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: |
           xcodebuild -project Space\ Bandits/Space\ Bandits.xcodeproj -configuration Release -scheme "Space Bandits" build CONFIGURATION_BUILD_DIR=`pwd`/build
           cd build


### PR DESCRIPTION
## Summary
- Remove the hardcoded `DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer` from the `make-release.yml` workflow
- `macOS-latest` runners no longer include Xcode 11.7, causing the release build to fail with `xcrun: error: missing DEVELOPER_DIR path`
- The `build.yml` workflow already uses the runner's default Xcode successfully

## Test plan
- [ ] Trigger the release workflow and verify the macOS build step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)