### PR TITLE
Fix hang on CoCo 3 with Multi-Pak Interface

### DIFF
--- a/engine/graphics-image.asm
+++ b/engine/graphics-image.asm
@@ -160,6 +160,7 @@ LoadLine@
 !           jsr         Decomp_Close_Stream
             * close the IMAGES.DAT file
             jsr         Disk_FileClose
+            jsr         System_LeaveDiskMode    * clear MPI CTS bits to prevent cartridge ROM bus contention
             rts
 
 

--- a/engine/loader.asm
+++ b/engine/loader.asm
@@ -675,6 +675,7 @@ NullWaveform@
             * close the SOUNDS.DAT file
             jsr         Disk_FileClose
 SkipSound2@
+            jsr         System_LeaveDiskMode    * clear MPI CTS bits to prevent cartridge ROM bus contention
             * disable progress callback
             ldx         #0
             jsr         Disk_SetProgressCallback

--- a/engine/system.asm
+++ b/engine/system.asm
@@ -111,6 +111,13 @@ System_InitHardware
             ldd         #(System_InterruptSWI+$103)
             std         $FEFB                   * replace SWI vector with "lbra System_InterruptSWI"
             andcc       #$AF                    * re-enable interrupts
+            * Save MPI register and clear CTS bits to prevent cartridge ROM
+            * from causing bus contention at $C000-$FEFF during gameplay.
+            * On systems without MPI, $FF7F reads $FF and writes are ignored.
+            lda         $FF7F                   * read current MPI state (SCS + CTS)
+            sta         System_MPI_SavedState
+            anda        #$0F                    * keep SCS bits (0-3), clear CTS bits (4-5)
+            sta         $FF7F                   * set CTS to slot 0 (least likely to have ROM)
             clr         $FF40                   * turn off drive motor
             clr         $986                    * clear DGRAM also, so Disk BASIC knows that drive motor was shut off
             rts
@@ -144,6 +151,8 @@ System_InitHardware
 * - Trashed: A
 ***********************************************************
 System_EnterDiskMode
+            lda         System_MPI_SavedState
+            sta         $FF7F                   * restore MPI to boot state for disk I/O
             lda         <MemMgr_VirtualTable+VH_BASIC0
             sta         $FFA0                   * map BASIC page 0 to $0000 (variables needed for disk basic rom)
             lda         <MemMgr_VirtualTable+VH_BASICROM
@@ -159,6 +168,9 @@ System_EnterDiskMode
 * - Trashed: A
 ***********************************************************
 System_LeaveDiskMode
+            lda         System_MPI_SavedState
+            anda        #$0F                    * keep SCS bits, clear CTS bits
+            sta         $FF7F                   * prevent cartridge ROM bus contention
             rts
 
 ***********************************************************
@@ -304,6 +316,7 @@ System_DisableAudioInterrupt
 ***********************************************************
 *
 System_SndBufferPtr      zmd     1
+System_MPI_SavedState    zmb     1               * saved Multi-Pak Interface register ($FF7F)
 *
 System_InterruptFIRQ_DAC6
             pshs        a

--- a/engine/system.asm
+++ b/engine/system.asm
@@ -111,14 +111,17 @@ System_InitHardware
             ldd         #(System_InterruptSWI+$103)
             std         $FEFB                   * replace SWI vector with "lbra System_InterruptSWI"
             andcc       #$AF                    * re-enable interrupts
-            * Save MPI register and clear CTS bits to prevent cartridge ROM
-            * from causing bus contention at $C000-$FEFF during gameplay.
+            * Save MPI register and clear SCS+CTS bits to prevent cartridge ROM
+            * bus contention ($C000-$FEFF) and cartridge I/O interference ($FF40-$FF5F).
+            * SCS must be cleared BEFORE writing $FF40, otherwise the write goes to
+            * whatever device is in the boot slot (e.g., CoCoSDC interprets $FF40
+            * differently than a standard FDC).
             * On systems without MPI, $FF7F reads $FF and writes are ignored.
             lda         $FF7F                   * read current MPI state (SCS + CTS)
             sta         System_MPI_SavedState
-            anda        #$0F                    * keep SCS bits (0-3), clear CTS bits (4-5)
-            sta         $FF7F                   * set CTS to slot 0 (least likely to have ROM)
-            clr         $FF40                   * turn off drive motor
+            clra                                * clear SCS (0-1) and CTS (4-5) bits
+            sta         $FF7F                   * disconnect all cartridge slots
+            clr         $FF40                   * turn off drive motor (now safely goes to slot 0)
             clr         $986                    * clear DGRAM also, so Disk BASIC knows that drive motor was shut off
             rts
 
@@ -168,9 +171,8 @@ System_EnterDiskMode
 * - Trashed: A
 ***********************************************************
 System_LeaveDiskMode
-            lda         System_MPI_SavedState
-            anda        #$0F                    * keep SCS bits, clear CTS bits
-            sta         $FF7F                   * prevent cartridge ROM bus contention
+            clra
+            sta         $FF7F                   * disconnect all cartridge slots (SCS=0, CTS=0)
             rts
 
 ***********************************************************


### PR DESCRIPTION
## Summary
- Save the MPI register (`$FF7F`) at startup and clear **both SCS and CTS bits** to prevent cartridge ROM bus contention at `$C000-$FEFF` and cartridge I/O interference at `$FF40-$FF5F`
- Restore the full MPI state in `System_EnterDiskMode` for disk I/O, then clear SCS+CTS again in `System_LeaveDiskMode`
- On systems without an MPI, `$FF7F` reads `$FF` and writes are ignored — this is a no-op

## Problem
On CoCo 3 systems with a Multi-Pak Interface, the game can hang during gameplay. There are two related issues:

### CTS bus contention (original fix)
The MPI's CTS (Cartridge ROM Select) bits route cartridge ROM onto the data bus at `$C000-$FEFF`, conflicting with the sprite erase buffer mapped there by the GIME MMU (`$FFA6`).

### SCS interference with CoCoSDC (new fix)
The original fix only cleared CTS but preserved SCS (Slot Communication Select, bits 0-1). This left the boot device's I/O registers active at `$FF40-$FF5F` during gameplay. The `clr $FF40` in `System_InitHardware` (intended to turn off the FDC drive motor) was being sent to whatever device occupied the boot slot.

The CoCoSDC interprets writes to `$FF40` differently than a standard WD FDC — its microcontroller uses these addresses as command registers. Writing 0 to the SDC's command register puts it in an unexpected state, causing the game to freeze approximately 1 second into gameplay (enemies have time to start shooting before the hang occurs).

**Key observations from hardware testing:**
- CoCoSDC works fine when plugged directly into the CoCo 3 (no MPI)
- CoCoSDC in MPI slot 1 or slot 4 → freeze ~1 second into level 1 gameplay
- HDB-DOS in MPI slot 1 or 4 → works fine (HDB-DOS is a simple ROM pak with no hardware at `$FF40`)
- Game loads successfully from SDC in all cases — the freeze only occurs during gameplay

**Fix:** Clear both SCS and CTS to 0 during gameplay, fully disconnecting all cartridge slots. SCS is cleared **before** the `$FF40` write so the motor-off command safely goes to slot 0 (empty). The full MPI state is still restored via `System_EnterDiskMode` when disk I/O is needed.

## Test plan
- [x] Verify clean build succeeds
- [ ] Test on CoCo 3 without MPI — should behave identically to before
- [ ] Test on CoCo 3 with MPI + HDB-DOS — should still work
- [ ] Test on CoCo 3 with MPI + CoCoSDC — should no longer freeze during gameplay
- [ ] Test disk I/O still works (level loading, sound loading) on all configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)